### PR TITLE
fix: switched to proper scheduler for fast/dev

### DIFF
--- a/hdi1/nf4.py
+++ b/hdi1/nf4.py
@@ -66,7 +66,7 @@ def load_models(model_type: str):
     
     pipe = HiDreamImagePipeline.from_pretrained(
         config["path"],
-        scheduler=FlowUniPCMultistepScheduler(num_train_timesteps=1000, shift=config["shift"], use_dynamic_shifting=False),
+        scheduler=config["scheduler"](num_train_timesteps=1000, shift=config["shift"], use_dynamic_shifting=False),
         tokenizer_4=tokenizer_4,
         text_encoder_4=text_encoder_4,
         torch_dtype=torch.bfloat16,


### PR DESCRIPTION
Seems like there was a typo in the model initialization on HiDream's repo.

The scheduler was hardcoded to `FlowUniPCMultistepScheduler` for Fast/Dev when it should be based on the model (i.e. Fast and Dev use `FlashFlowMatchEulerDiscreteScheduler`). They pushed a fix at https://github.com/HiDream-ai/HiDream-I1/commit/6629d04d71c5f344298128dd69af42505d0745a0.

This PR just copies the same fix to this repo. Testing locally, I can't see much of a difference on Fast, but if it was intended to vary per-model then it's probably a good idea to keep that intact here as well.